### PR TITLE
Updates dataset name from data-004 to cefas-plankton

### DIFF
--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -10,7 +10,7 @@ def test_workflow():
     targetmodel = models[models.name == model_name].url.item()
     model = load_pretrained_model(targetmodel, allow_install=True)
 
-    target_datasource = compatible_datasources.loc[compatible_datasources['name'] == 'data-004']
+    target_datasource = compatible_datasources.loc[compatible_datasources['name'] == 'cefas-plankton']
     cat = load_dataset(target_datasource.url.item())
     dataset = cat.plankton().to_dask()
 


### PR DESCRIPTION
Following the updates to Scivision 0.5.0, `data-004` was renamed `cefas-plankton`. This change is now reflected in the test, as discussed in [#83](https://github.com/alan-turing-institute/DS4S-project-management/issues/83)